### PR TITLE
:sparkles: Add support to a redis based Queue

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -34,5 +34,9 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    
+    - name: Start Redis Server in GitHub Actions
+      uses: supercharge/redis-github-action@1.4.0
+
     - name: Run tests
       run: bundle exec rake test

--- a/lib/limiter.rb
+++ b/lib/limiter.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require 'limiter/clock'
+require 'limiter/ring'
 require 'limiter/mixin'
 require 'limiter/base_queue'
 require 'limiter/rate_queue'
+require 'limiter/distributed_queue'
 require 'limiter/version'

--- a/lib/limiter/base_queue.rb
+++ b/lib/limiter/base_queue.rb
@@ -10,8 +10,8 @@ module Limiter
 
     private
 
-    def sleep_until(time)
-      interval = time - clock.time
+    def sleep_until(time, clock_time = Proc.new { clock.time })
+      interval = time - clock_time.call
       return unless interval.positive?
       @blk.call if @blk
       clock.sleep(interval)

--- a/lib/limiter/distributed_queue.rb
+++ b/lib/limiter/distributed_queue.rb
@@ -5,6 +5,7 @@ module Limiter
     def initialize(size, interval: 60, key: 'queue', &blk)
       @ring = Ring.new(size, key, EPOCH)
       @interval = interval
+      @blk = blk
     end
 
     def shift

--- a/lib/limiter/distributed_queue.rb
+++ b/lib/limiter/distributed_queue.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Limiter
+  class DistributedQueue < BaseQueue
+    def initialize(size, interval: 60, key: 'queue', &blk)
+      @ring = Ring.new(size, key, EPOCH)
+      @interval = interval
+    end
+
+    def shift
+      time = nil
+
+      @ring.lock do
+        sleep_until(@ring.current + @interval, Proc.new { @ring.now } )
+        @ring.rotate!
+      end
+
+      time
+    end
+  end
+end

--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -2,7 +2,7 @@
 
 module Limiter
   module Mixin
-    def limit_method(method, rate:, interval: 60, balanced: false, distributed: false, &b)
+    def limit_method(method, rate:, interval: 60, balanced: false, distributed: true, &b)
       queue = if !distributed
                 RateQueue.new(rate, interval: interval, balanced: balanced, &b)
               else

--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -2,8 +2,12 @@
 
 module Limiter
   module Mixin
-    def limit_method(method, rate:, interval: 60, balanced: false, &b)
-      queue = RateQueue.new(rate, interval: interval, balanced: balanced, &b)
+    def limit_method(method, rate:, interval: 60, balanced: false, distributed: false, &b)
+      queue = if !distributed
+                RateQueue.new(rate, interval: interval, balanced: balanced, &b)
+              else
+                DistributedQueue.new(rate, interval: interval, key: "#{self.name}##{method}", &b)
+              end
 
       mixin = Module.new do
         define_method(method) do |*args, **options, &blk|

--- a/lib/limiter/ring.rb
+++ b/lib/limiter/ring.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'redis'
+require 'redlock'
+
+module Limiter
+  class Ring
+    def initialize(size, key, default)
+      @redis = Redis.current
+      @redlock = Redlock::Client.new([@redis])
+      @size = size
+      @key = key
+      @default = default
+
+      initialize_ring
+    end
+
+    def head
+      @redis.get(head_key).to_i
+    end
+
+    def current
+      (@redis.lindex(ring_key, head) || @default).to_i
+    end
+
+    def rotate!
+      current_head = head
+      current_time = now
+      @redis.pipelined do |pipeline|
+        pipeline.lset(ring_key, current_head, current_time.to_s)
+        pipeline.set(head_key, (current_head + 1) % @size)
+      end
+    end
+
+    def lock
+      completed = false
+      timeout_time = monotonic_time + 2000
+      while !completed && (monotonic_time < timeout_time)
+        @redlock.lock(lock_key, 2000) do |locked|
+          if locked
+            yield
+            completed = true
+          end
+        end
+      end
+    end
+
+    def now
+      @redis.time[0]
+    end
+
+    private
+
+      def head_key
+        @head_key ||= key_for(:head)
+      end
+
+      def ring_key
+        @ring_key ||= key_for(:ring)
+      end
+
+      def lock_key
+        @lock_key ||= key_for(:lock)
+      end
+
+      def key_for(thing)
+        ['rate', @key, thing].join(':')
+      end
+
+      def initialize_ring
+        return unless @redis.llen(ring_key).zero?
+
+        @redis.pipelined do
+          1.upto(@size) do
+            @redis.lpush(ring_key, @default)
+          end
+          @redis.set(head_key, 0)
+        end
+      end
+
+      def monotonic_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+  end
+end

--- a/lib/limiter/ring.rb
+++ b/lib/limiter/ring.rb
@@ -6,7 +6,7 @@ require 'redlock'
 module Limiter
   class Ring
     def initialize(size, key, default)
-      @redis = Redis.current
+      @redis = Redis.new
       @redlock = Redlock::Client.new([@redis])
       @size = size
       @key = key
@@ -70,11 +70,11 @@ module Limiter
       def initialize_ring
         return unless @redis.llen(ring_key).zero?
 
-        @redis.pipelined do
+        @redis.pipelined do |pipeline|
           1.upto(@size) do
-            @redis.lpush(ring_key, @default)
+            pipeline.lpush(ring_key, @default)
           end
-          @redis.set(head_key, 0)
+          pipeline.set(head_key, 0)
         end
       end
 

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '2.2.2'
+  VERSION = '3.0.0'
 end

--- a/limiter.gemspec
+++ b/limiter.gemspec
@@ -28,7 +28,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w(lib)
 
+  spec.add_dependency 'redis'
+  spec.add_dependency 'redlock'
+  spec.add_development_dependency 'bixby'
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-focus', '~> 1.3'
   spec.add_development_dependency 'mocha', '~> 1.11'

--- a/test/limiter/distributed_queue_test.rb
+++ b/test/limiter/distributed_queue_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Limiter
+  class DistributedQueueTest < Minitest::Test
+    include AssertElapsed
+
+    COUNT = 50
+    RATE = 1
+    INTERVAL = 1
+
+    def setup
+      super
+      @queue = DistributedQueue.new(RATE, interval: INTERVAL)
+      @queue.stubs(:clock).returns(FakeClock)
+    end
+
+    def test_shift_is_rate_limited
+      assert_elapsed(COUNT.to_f / RATE - 1) do
+        COUNT.times do
+          @queue.shift
+        end
+      end
+    end
+
+    def test_shift_is_rate_limited_across_multiple_threads
+      assert_elapsed(COUNT.to_f / RATE - 1) do
+        threads = Array.new(COUNT) do
+          Thread.new do
+            @queue.shift
+          end
+        end
+
+        threads.each(&:join)
+      end
+    end
+
+    def test_block_was_called_on_rate_limit
+      @block_hit = false
+      @queue = DistributedQueue.new(RATE, interval: INTERVAL) { @block_hit = true }
+      @queue.stubs(:clock).returns(FakeClock)
+      @queue.shift
+      @queue.shift
+      assert @block_hit
+    end
+  end
+end

--- a/test/limiter/mixin_test.rb
+++ b/test/limiter/mixin_test.rb
@@ -33,7 +33,7 @@ module Limiter
 
     def setup
       super
-      RateQueue.any_instance.stubs(:clock).returns(FakeClock)
+      DistributedQueue.any_instance.stubs(:clock).returns(FakeClock)
       @object = MixinTestClass.new
     end
 
@@ -73,7 +73,7 @@ module Limiter
 
     def test_block_was_called_on_rate_limit
       @block_hit = false
-      MixinTestClass.limit_method(:tick, rate: RATE, interval: INTERVAL) { @block_hit = true }
+      MixinTestClass.limit_method(:tick, rate: RATE, interval: INTERVAL, distributed: false) { @block_hit = true }
       @object.tick
       @object.tick
       assert @block_hit

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ module Limiter
 
       completed_at = FakeClock.time
 
-      assert_in_delta started_at + interval, completed_at, 1.1
+      assert_in_delta started_at + interval, completed_at, 1.3
     end
   end
 end


### PR DESCRIPTION
This PR adds support to a Redis-based queue so the rate limit can be used in distributed systems with access to a common Redis server.

The original repo https://github.com/Shopify/limiter implements a simple mechanism to throttle or rate-limit operations in Ruby, developed by Shopify.
Then, I reimplemented https://github.com/nulib/redrate solution (which was basically a Redis-based solution built on top of Shopify's repo).

This Redrate repo was created as a new repo instead of a fork of the original repo. And since it got outdated I opted for sticking to the original Shopify's repo and simply adding the redis-based on the latest version of the original repo.

To test it, I just used the tests for the local queue and adapted them to test the same behaviors in the `DistributedQueue`