### PR TITLE
:recycle: Stop calling redis on initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # CHANGELOG
+​
+## v3.0.1
+​
+- Stop calling Redis on initialization
+
+## v3.0.0
+
+- Add support to redis-based queues for distributed systems
 
 ## v2.2.2
 

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
The way the Redis solution was implemented was forcing a call to the Redis on initialization before everything was set up and unnecessarily.
Now it will only happen on the fly (checking if it hasn't already been initialized)