### PR TITLE
♻️ Refactor redis queue naming default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 ​
+## v3.1.0
+​
+- Set a more specific queue default name for redis-based queues
+
 ## v3.0.1
 ​
 - Stop calling Redis on initialization

--- a/lib/limiter/distributed_queue.rb
+++ b/lib/limiter/distributed_queue.rb
@@ -2,7 +2,7 @@
 
 module Limiter
   class DistributedQueue < BaseQueue
-    def initialize(size, interval: 60, key: 'queue', &blk)
+    def initialize(size, key, interval: 60, &blk)
       @ring = Ring.new(size, key, EPOCH)
       @interval = interval
       @blk = blk

--- a/lib/limiter/mixin.rb
+++ b/lib/limiter/mixin.rb
@@ -2,11 +2,11 @@
 
 module Limiter
   module Mixin
-    def limit_method(method, rate:, interval: 60, balanced: false, distributed: true, &b)
+    def limit_method(method, rate:, key: "#{self.name}##{method}", interval: 60, balanced: false, distributed: true, &b)
       queue = if !distributed
                 RateQueue.new(rate, interval: interval, balanced: balanced, &b)
               else
-                DistributedQueue.new(rate, interval: interval, key: "#{self.name}##{method}", &b)
+                DistributedQueue.new(rate, key, interval: interval, &b)
               end
 
       mixin = Module.new do

--- a/lib/limiter/ring.rb
+++ b/lib/limiter/ring.rb
@@ -11,6 +11,7 @@ module Limiter
       @size = size
       @key = key
       @default = default
+      @already_initialized = false
     end
 
     def head

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '3.0.1'
+  VERSION = '3.1.0'
 end

--- a/test/limiter/distributed_queue_test.rb
+++ b/test/limiter/distributed_queue_test.rb
@@ -12,7 +12,7 @@ module Limiter
 
     def setup
       super
-      @queue = DistributedQueue.new(RATE, interval: INTERVAL)
+      @queue = DistributedQueue.new(RATE, "Limiter::DistributedQueueTest", interval: INTERVAL)
       @queue.stubs(:clock).returns(FakeClock)
     end
 
@@ -38,7 +38,7 @@ module Limiter
 
     def test_block_was_called_on_rate_limit
       @block_hit = false
-      @queue = DistributedQueue.new(RATE, interval: INTERVAL) { @block_hit = true }
+      @queue = DistributedQueue.new(RATE, "Limiter::DistributedQueueTest", interval: INTERVAL) { @block_hit = true }
       @queue.stubs(:clock).returns(FakeClock)
       @queue.shift
       @queue.shift

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ module Limiter
 
       completed_at = FakeClock.time
 
-      assert_in_delta started_at + interval, completed_at, 1.3
+      assert_in_delta started_at + interval, completed_at, 1.4
     end
   end
 end


### PR DESCRIPTION
We were using by default a queue named "queue" for the redis-based queues. Now we will defaultly name it using the Class and the mehod name to try to make it more unique in cases where the user doesn't really need to bother in passing a key.

## Example without passing a `key` value

![image](https://user-images.githubusercontent.com/19315023/178063106-21559afb-dd90-43dd-96eb-915bfd9f7220.png)

