### PR TITLE
:sparkles: Add `#check` alias method for queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # CHANGELOG
-​
+
+## v3.2.0
+
+- Add an alias `#check!` method to be called in the queues instead of `shift`
+
 ## v3.1.0
-​
+
 - Set a more specific queue default name for redis-based queues
 
 ## v3.0.1
-​
+
 - Stop calling Redis on initialization
 
 ## v3.0.0

--- a/lib/limiter/base_queue.rb
+++ b/lib/limiter/base_queue.rb
@@ -8,6 +8,12 @@ module Limiter
       raise ArgumentError, "This method should be implemented in a child class"
     end
 
+    # Sometimes we will use the queues directly to check for rate limits,
+    # and calling `#shift` doesn't make much sense when we are talking
+    # from a rate limit point of view - it only makes sense if we know the underlying
+    # building block is based in a Ring data structure
+    alias :check! :shift
+
     private
 
     def sleep_until(time, clock_time = Proc.new { clock.time })

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '3.1.0'
+  VERSION = '3.2.0'
 end


### PR DESCRIPTION
Sometimes we will use the queues directly to check for rate limits,
and calling `#shift` doesn't make much sense when we are talking
from a rate limit point of view - it only makes sense if we know the underlying
building block is based in a Ring data structure