### PR TITLE
:bug: Properly alias `#check!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v3.2.1
+
+- Properly alias `#check!` method to be called in the queues instead of `shift` by using [`forwardable`](https://ruby-doc.org/stdlib-2.6.3/libdoc/forwardable/rdoc/Forwardable.html)
+
 ## v3.2.0
 
 - Add an alias `#check!` method to be called in the queues instead of `shift`

--- a/lib/limiter/base_queue.rb
+++ b/lib/limiter/base_queue.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require 'forwardable'
+
 module Limiter
   class BaseQueue
+    extend Forwardable
+
     EPOCH = 0.0
 
     def shift
@@ -12,7 +16,7 @@ module Limiter
     # and calling `#shift` doesn't make much sense when we are talking
     # from a rate limit point of view - it only makes sense if we know the underlying
     # building block is based in a Ring data structure
-    alias :check! :shift
+    def_delegator :self, :shift, :check!
 
     private
 

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end

--- a/test/limiter/distributed_queue_test.rb
+++ b/test/limiter/distributed_queue_test.rb
@@ -24,6 +24,14 @@ module Limiter
       end
     end
 
+    def test_check_is_aliased_to_shift
+      assert_elapsed(COUNT.to_f / RATE - 1) do
+        COUNT.times do
+          @queue.check!
+        end
+      end
+    end
+
     def test_shift_is_rate_limited_across_multiple_threads
       assert_elapsed(COUNT.to_f / RATE - 1) do
         threads = Array.new(COUNT) do

--- a/test/limiter/rate_queue_test.rb
+++ b/test/limiter/rate_queue_test.rb
@@ -24,6 +24,14 @@ module Limiter
       end
     end
 
+    def test_check_is_aliased_to_shift
+      assert_elapsed(COUNT.to_f / RATE - 1) do
+        COUNT.times do
+          @queue.check!
+        end
+      end
+    end
+
     def test_shift_is_rate_limited_across_multiple_threads
       assert_elapsed(COUNT.to_f / RATE - 1) do
         threads = Array.new(COUNT) do


### PR DESCRIPTION
The previous usage wouldn't properly delegate it because `alias` work in the class level using the original class `self` instead of running at runtime properly creating the alias in subclasses.