### PR TITLE
Add configurable Redis isntance for Ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v3.3.0
+
+- Add a new `Ring#configure` method allowing you to set a specific Redis instance to be used by `limiter`
+-
+
 ## v3.2.1
 
 - Properly alias `#check!` method to be called in the queues instead of `shift` by using [`forwardable`](https://ruby-doc.org/stdlib-2.6.3/libdoc/forwardable/rdoc/Forwardable.html)

--- a/lib/limiter/ring.rb
+++ b/lib/limiter/ring.rb
@@ -11,7 +11,7 @@ module Limiter
     end
 
     def initialize(size, key, default)
-      @redis = config.redis || Redis.new
+      @redis = Ring.config.redis || Redis.new
       @redlock = Redlock::Client.new([@redis])
       @size = size
       @key = key

--- a/lib/limiter/ring.rb
+++ b/lib/limiter/ring.rb
@@ -5,13 +5,27 @@ require 'redlock'
 
 module Limiter
   class Ring
+    
+    class Config
+      attr_accessor :redis
+    end
+
     def initialize(size, key, default)
-      @redis = Redis.new
+      @redis = config.redis || Redis.new
       @redlock = Redlock::Client.new([@redis])
       @size = size
       @key = key
       @default = default
       @already_initialized = false
+    end
+
+    def self.configure
+      yield config
+      config
+    end
+
+    def self.config
+      @@config ||= Config.new
     end
 
     def head

--- a/lib/limiter/version.rb
+++ b/lib/limiter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Limiter
-  VERSION = '3.2.1'
+  VERSION = '3.3.0'
 end


### PR DESCRIPTION
We are always creating a new Redis instance whenever we create a Ring which is causing us to create too many instances in LeadSimple because they aren't being closed appropriately.